### PR TITLE
resistances are inversed between P and AP state !

### DIFF
--- a/src/verilog_a_compact_model/mram_lib/mtj_subcircuit.scs
+++ b/src/verilog_a_compact_model/mram_lib/mtj_subcircuit.scs
@@ -34,7 +34,7 @@ v_aux (aux_1 0) bsource v=v(fl, pl)
 r_aux (aux_0 0) resistor r=1
 
 // simple TMR based conduction
-r_mtj_module (fl pl) bsource r=p_r_p*(1 + p_tmr/(p_tmr + 2))/(1 - p_tmr/(p_tmr + 2)*V(mz))
+r_mtj_module (fl pl) bsource r=p_r_p*(1 + p_tmr/(p_tmr + 2))/(1 + p_tmr/(p_tmr + 2)*V(mz))
 
 ends mtj_subcircuit
 


### PR DESCRIPTION
*** The resistance should be high at anti-parallel (AP) state and low at parallel state (P) *** 
- The pinned layer magnetization vector is initialized UP ( p_theta_pl = 0 and pl_z = 1)
- The parallel state requires the magnetization vector of the free layer to be UP also (m_theta= 0 and m_z = 1) The formula R = f(mz) should be corrected as follows in order to get low resistance when V(mz) = 1 : // simple TMR based conduction
r_mtj_module (fl pl) bsource r=p_r_p*(1 + p_tmr/(p_tmr + 2))/(1 + p_tmr/(p_tmr + 2)*V(mz))