### PR TITLE
Fix exponential discretization

### DIFF
--- a/src/fokker_plank/fvm/README.md
+++ b/src/fokker_plank/fvm/README.md
@@ -7,6 +7,10 @@ Switching Distributions for Perpendicular Spin-Torque Devices Within the Macrosp
 
 This note explains how the paper’s θ-form Fokker–Planck equation is implemented in the repository, and why the explicit metric factor $1/\sin\theta$ does **not** appear in the code.
 
+
+## `fvm_classes.py` 
+`fvm_classes.py` Finite Volume Method classes, see [FVM](https://github.com/danieljfarrell/FVM and [FVM2](https://github.com/Fratorhe/FVM/))
+
 ---
 
 ## 1) Equation in $ \theta $ (paper) and change of variables

--- a/src/fokker_plank/fvm/mtj_fp_fvm.py
+++ b/src/fokker_plank/fvm/mtj_fp_fvm.py
@@ -25,7 +25,7 @@ np.random.seed(seed=1)
 def solve_mtj_fp(
     dim_points=1000,
     rho_init=None,
-    delta=60,
+    delta=60.0,
     i0=1.5,
     h=0.0,
     t_step=0.001,


### PR DESCRIPTION
Fix numerical bug in the 1D “exponential” discretization (the kappa/Péclet handling), ocurring for small Delta MTJs.

small-ish delta ⇒ diffusion larger ⇒ Péclet 
μ=a Δx/d
μ=aΔx/d becomes very small in parts of the domain (especially when the drift crosses 0, e.g. phase with i≈0).